### PR TITLE
ADD packages required for Centos-PaaS-Sig usage

### DIFF
--- a/centos-7.template
+++ b/centos-7.template
@@ -22,6 +22,7 @@ repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
 repo --name=extras --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
 repo --name=atomic --baseurl=http://mirror.centos.org/centos/7/atomic/x86_64/adb/
 repo --name=hvkvp --baseurl=http://files.gbraad.nl/hvkvp/
+repo --name=epel --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=x86_64
 
 shutdown
 
@@ -47,6 +48,10 @@ cifs-utils
 fuse-sshfs
 nfs-utils
 go-hvkvp
+libvirt
+qemu-system-x86
+qemu-kvm
+epel-release
 
 #Packages to be removed
 -aic94xx-firmware
@@ -214,6 +219,7 @@ systemctl disable NetworkManager-wait-online
 systemctl enable minishift-handle-user-data
 systemctl enable minishift-set-ipaddress
 systemctl enable docker
+systemctl enable libvirtd
 
 
 # Clean


### PR DESCRIPTION
Added qemu-system-x86, qemu-kvm, and libvirt to the packages installed
to the existing centos-7 template. This allows for nested containers to
use libvirtd